### PR TITLE
Correct some typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Then to start an interactive unix shell:
 The language runtimes in w64devkit are optimized for size, so it produces
 particularly small binaries when programs are also optimized for size
 (`-Os`) during compilation. If your program only uses the `printf` family
-of functions with MSVC-compatable directivies (i.e. limited to C89), and
-you want even smaller binaries, you can avoid embdedding the Mingw-w64's
+of functions with MSVC-compatible directives (i.e. limited to C89), and
+you want even smaller binaries, you can avoid embedding the Mingw-w64's
 improved implementation by setting `__USE_MINGW_ANSI_STDIO` to 0 before
 including any headers.
 


### PR DESCRIPTION
I noticed some typos in README.md so I went ahead and fixed them
I checked over the rest of the file with vim `:spell` option and noticed nothing else wrong.