### PR TITLE
Build automatically using GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: Build and test
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+
+# Must set Settings -> Actions -> General -> Workflow permissions to
+# "Read and write permissions"
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["x64", "x86"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply x86 patch
+        if: matrix.arch == 'x86'
+        run: patch -p1 -i src/variant-x86.patch
+
+      - name: Generate archive name and version string
+        id: filename
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          GIT_VERSION="$(git describe --tags --always)"
+          echo "version=${GIT_VERSION:1}" >> $GITHUB_OUTPUT
+          echo "archive=w64devkit-$ARCH-${GIT_VERSION:1}" >> $GITHUB_OUTPUT
+
+      - name: Build
+        run: |
+          docker build -t w64devkit .
+          docker run --rm w64devkit > ${{ steps.filename.outputs.archive }}.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.filename.outputs.archive }}
+          path: w64devkit-*.exe
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.filename.outputs.version }}
+          files: w64devkit-*.exe
+          draft: true


### PR DESCRIPTION
Yet another feature that made me think that if it's useful for me, there's a chance it might be useful for others :)

This uses GitHub Actions to automatically build w64devkit.

-----------------

This is the way I made it for myself, I'm open to bring modifications to the PR if something in there would be interesting.

The builds are triggered on either of two events:
1. Each commit pushed to master, and each pull request open to master, which upload builds to the Action page ([example](https://github.com/Semphriss/w64devkit/actions/runs/5445984557)):
![Screenshot of the workflow page showing downloadable builds, as linked by the "example" link above.](https://github.com/skeeto/w64devkit/assets/66701383/4cfdb46f-c87a-4f9a-8303-76876710b6dd)
This offers a nice an easy way to download builds for any commit on the master branch. Unfortunately, those are only available for logged in users.

2. Each tag pushed on the repo, which automatically uploads the builds to a new release marked as draft ([example](https://github.com/Semphriss/w64devkit/releases/tag/v1.19.1) - the only thing I did manually was to publish the release):
![Screenshot of the release page, as linked by the "example" link above.](https://github.com/skeeto/w64devkit/assets/66701383/8bb07935-090f-4450-9b35-0db9286b7f28)
This offers a ready-made template for releases based on git tags. I tried to strictly follow the format used by the latest releases, as to minimize manual intervention, but the release is not automatically published by GitHub Actions, so manual intervention is always possible before publishing a release.

---------------

The upsides I've noticed:
- The builds happen on GitHub rather than on my machine, so I don't have to wait 30 or so minutes per build before my machine becomes usable again (or before I can power it off and switch OS).
- The builds run in parallel on GitHub, because it uses one VM for each architecture-flavor pair. Locally, each build would have to be done one at a time, or the machine's cores would be divided between each concurrent build.
- It allows effortlessly seeing when a PR or a commit breaks the builds, and in the case of PRs, it allows the author of the PR to notice those errors by themselves without needing active feedback from others.
- It offers a reliable, somewhat reproducible (or at least well-documented) environment to build w64devkit in. Also,  in situations where it might be an issue, there's no need to trust that anybody didn't tamper with the files.

The downsides:
- It takes 1h30 to finish all builds, and no download is available before all builds finished. For single configurations, building locally may be faster. However, for an all-configs build (6 configs * 30 minutes per config on average = 3 hours total), GitHub Actions remains faster.

---------------

If there's interest in this PR, I can explain in further detail any decision I took while creating the workflow file. I'm also willing to adapt this PR as necessary.