### PR TITLE
Update w64devkit.c

### DIFF
--- a/src/w64devkit.c
+++ b/src/w64devkit.c
@@ -162,10 +162,11 @@ mainCRTStartup(void)
     if (args && *args != 0) {
         WCHAR* s = cmdline + COUNTOF(CMDLINE_SH_LOGIN) - 1;
         for ( ; *args; args++) {
+            if(*args == '\\' && args[1] == '\"') *s++ = '\\';
             *s++ = *args;
         }
         *s = 0;
-	}
+    }
 
     /* Start a BusyBox login shell */
     STARTUPINFOW si;


### PR DESCRIPTION
Fixes fatal() to use ExitProcess() instead.
Passes any arguments received to onto the shell login (i use this together with ConEmu-Here to change the working directory and even execute files from .profile)
Adds a terminal title.
Increases stack size for the passing of arguments.