### PR TITLE
New runtime library: libmemory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN sha256sum -c $PREFIX/src/SHA256SUMS \
  && tar xJf nasm-$NASM_VERSION.tar.xz \
  && tar xjf vim-$VIM_VERSION.tar.bz2 \
  && tar xzf cppcheck-$CPPCHECK_VERSION.tar.gz
-COPY src/w64devkit.c src/w64devkit.ico \
+COPY src/w64devkit.c src/w64devkit.ico src/libmemory.c \
      src/alias.c src/debugbreak.c src/pkg-config.c src/vc++filt.c \
      $PREFIX/src/
 
@@ -122,6 +122,10 @@ RUN cat $PREFIX/src/gcc-*.patch | patch -d/gcc-$GCC_VERSION -p1 \
  && make install-gcc
 
 ENV PATH="/bootstrap/bin:${PATH}"
+
+RUN mkdir -p $PREFIX/$ARCH/lib \
+ && CC=$ARCH-gcc DESTDIR=$PREFIX/$ARCH/lib/ sh $PREFIX/src/libmemory.c \
+ && ln $PREFIX/$ARCH/lib/libmemory.a /bootstrap/$ARCH/lib/
 
 WORKDIR /x-mingw-crt
 RUN /mingw-w64-v$MINGW_VERSION/mingw-w64-crt/configure \

--- a/src/libmemory.c
+++ b/src/libmemory.c
@@ -10,8 +10,8 @@ for func in memset memcpy memmove memcmp strlen; do
     objects="$objects $func.o"
     (set -x; ${CC:-cc} -c -D$FUNC -Wa,--no-pad-sections $CFLAGS -o $func.o $0)
 done
-rm -f libmemory.a
-ar r ${DESTDIR}libmemory.a $objects
+rm -f "${DESTDIR}libmemory.a"
+ar r "${DESTDIR}libmemory.a" $objects
 rm $objects
 exit 0
 #endif

--- a/src/libmemory.c
+++ b/src/libmemory.c
@@ -50,6 +50,10 @@ void *memcpy(void *restrict dst, void *restrict src, size_t len)
 #ifdef MEMMOVE
 void *memmove(void *dst, void *src, size_t len)
 {
+    // Use uintptr_t to bypass pointer semantics:
+    // (1) comparing unrelated pointers
+    // (2) pointer arithmetic on null (i.e. gracefully handle null dst/src)
+    // (3) pointer overflow ("one-before-the-beginning" in reversed copy)
     uintptr_t d = (uintptr_t)dst;
     uintptr_t s = (uintptr_t)src;
     if (d > s) {

--- a/src/libmemory.c
+++ b/src/libmemory.c
@@ -16,7 +16,8 @@ rm $objects
 exit 0
 #endif
 
-typedef __SIZE_TYPE__ size_t;
+typedef __SIZE_TYPE__    size_t;
+typedef __UINTPTR_TYPE__ uintptr_t;
 
 #ifdef MEMSET
 void *memset(void *dst, int c, size_t len)
@@ -49,19 +50,20 @@ void *memcpy(void *restrict dst, void *restrict src, size_t len)
 #ifdef MEMMOVE
 void *memmove(void *dst, void *src, size_t len)
 {
-    void *r = dst;
-    if ((size_t)dst > (size_t)src) {
-        dst += len - 1;
-        src += len - 1;
+    uintptr_t d = (uintptr_t)dst;
+    uintptr_t s = (uintptr_t)src;
+    if (d > s) {
+        d += len - 1;
+        s += len - 1;
         asm ("std");
     }
     asm volatile (
         "rep movsb; cld"
-        : "+D"(dst), "+S"(src), "+c"(len)
+        : "+D"(d), "+S"(s), "+c"(len)
         :
         : "memory"
     );
-    return r;
+    return dst;
 }
 #endif
 

--- a/src/libmemory.c
+++ b/src/libmemory.c
@@ -1,0 +1,94 @@
+#if 0
+# memset, memcpy, memmove, and memcmp via x86 string instructions
+# Execute this source with a shell to build libmemory.a.
+# This is free and unencumbered software released into the public domain.
+set -e
+CFLAGS="-Os -fno-builtin -fno-asynchronous-unwind-tables -fno-ident"
+objects=""
+for func in memset memcpy memmove memcmp strlen; do
+    FUNC="$(echo $func | tr '[:lower:]' '[:upper:]')"
+    objects="$objects $func.o"
+    (set -x; ${CC:-cc} -c -D$FUNC -Wa,--no-pad-sections $CFLAGS -o $func.o $0)
+done
+rm -f libmemory.a
+ar r ${DESTDIR}libmemory.a $objects
+rm $objects
+exit 0
+#endif
+
+typedef __SIZE_TYPE__ size_t;
+
+#ifdef MEMSET
+void *memset(void *dst, int c, size_t len)
+{
+    void *r = dst;
+    asm volatile (
+        "rep stosb"
+        : "+D"(dst), "+c"(len)
+        : "a"(c)
+        : "memory"
+    );
+    return r;
+}
+#endif
+
+#ifdef MEMCPY
+void *memcpy(void *restrict dst, void *restrict src, size_t len)
+{
+    void *r = dst;
+    asm volatile (
+        "rep movsb"
+        : "+D"(dst), "+S"(src), "+c"(len)
+        :
+        : "memory"
+    );
+    return r;
+}
+#endif
+
+#ifdef MEMMOVE
+void *memmove(void *dst, void *src, size_t len)
+{
+    void *r = dst;
+    if ((size_t)dst > (size_t)src) {
+        dst += len - 1;
+        src += len - 1;
+        asm ("std");
+    }
+    asm volatile (
+        "rep movsb; cld"
+        : "+D"(dst), "+S"(src), "+c"(len)
+        :
+        : "memory"
+    );
+    return r;
+}
+#endif
+
+#ifdef MEMCMP
+int memcmp(void *s1, void *s2, size_t len)
+{
+    int a, b;
+    asm volatile (
+        "test %%eax, %%eax; repz cmpsb"
+        : "+D"(s1), "+S"(s2), "+c"(len), "=@cca"(a), "=@ccb"(b)
+        :
+        : "memory"
+    );
+    return b - a;
+}
+#endif
+
+#ifdef STRLEN
+size_t strlen(char *s)
+{
+    size_t n = -1;
+    asm volatile (
+        "repne scasb"
+        : "+D"(s), "+c"(n)
+        : "a"(0)
+        : "memory"
+    );
+    return -n - 2;
+}
+#endif


### PR DESCRIPTION
This static library provides memset, memcpy, memmove, memcmp, and strlen. The implementations are minimal wrappers around x86 string instructions, making them both tiny (~25 bytes apiece) and reasonably performant, though not nearly as fast as CRT implementations. I selected these particular functions because GCC fabricates calls to each out of thin air at some optimization levels. The first four are also genuinely useful as built-ins (__builtin_memset, etc.), keeping in mind arbitrary limitations with null.

Mingw-w64 does not implement them but instead offers imports from system DLLs: -lmsvcrt, -lmsvcr120, -lucrt, -lntdllcrt. It creates a dependency on a system DLL: practical, though unoptimal, and no licensing woes. With -nostartfiles instead of -nostdlib, this happens implicitly.

MSVC provides static definitions in libvcuntime.lib, useful when cl or clang-cl fabricates calls. They weigh several KB each, and require the application or installer to present a EULA ("external end users to agree to terms"). Not a great trade-off just for some basic memory functions.

In w64devkit, libmemory fills this role. It's a public domain library so there are no license terms. Just add -lmemory to the build command. It also allows liberal use of the associated built-ins, especially in debug builds, which can benefit from fast memory operations despite -O0. MSVC toolchains can also freely use libmemory.a, though it won't know how to find it without help of course.

I do not plan to add more functions except for cases of GCC fabricating calls (e.g. strlen). Certainly no null-terminated string functions.

* * *

I'm interested in feedback before settling the details (@N-R-K, @Peter0x44). (Responses in my public inbox are welcome, too.) I'm not particularly attached to the name (`-lmemory`), but I don't see anything wrong with it unless there's some convention of which I'm unaware. I've been dogfooding this branch, and this little library has already proven useful.

First, as noted, this basically eliminates problems with GCC inserting calls to these functions, at least within w64dekvit. That includes software built for w64devkit (u-config, etc.), as it's built during bootstrap, though nothing uses it yet.

Second, as I later discovered, the matching GCC built-ins are now as reliable as intrinsics. They Just Work, even without a CRT, exactly the way I want, and I don't have to worry about supplying implementations later. GCC will do smart things with the built-ins even at low optimization levels. For example, `-O1` isn't enough for GCC to unroll/vectorize copy/zero loops, but with `__builtin_*` it's as smart as `-O2`. At `-O0` it's a call into `libmemory`, which is fast without hurting debugging. With hand-written loops, memory copying/zeroing/etc. are bottlenecks at `-O0` (lots of iterations with lots of instructions per byte), but with built-ins my debug builds are practically as fast as my "release" builds.

Here are some samples. A quick allocator, fast even in release builds:

```c
static char *alloc(arena *a, int size, int count)
{
    int align = -((unsigned)size*count) & (sizeof(void *) - 1);
    if (count > (a->end - a->beg - align)/size) {
        __builtin_trap();
    }
    a->end -= align + size*count;
    return __builtin_memset(a->end, 0, size*count);
}
```

String comparison (deals with the stupid null thing, too):

```c
static int strequals(str a, str b)
{
    return a.len==b.len && !(a.len && __builtin_memcmp(a.data, b.data, a.len));
}
```

String cloning:

```c
static str strclone(str s, arena *perm)
{
    str r = {0};
    r.data = new(perm, char, s.len);
    r.len = s.len;
    if (s.len) __builtin_memcpy(r.data, s.data, s.len);
    return r;
}
```

Putting it all together, this string table is practically as fast at `-O0` as `-O3`!

```c
typedef struct tab tab;
struct tab {
    tab *child[2];
    str  key;
};

static str intern(tab **t, str key, arena *perm)
{
    for (unsigned h = strhash(key); *t; h <<= 1) {
        if (strequals((*t)->key, key)) {
            return (*t)->key;
        }
        t = &(*t)->child[h>>31];
    }
    return (*t = new(perm, tab, 1))->key = strclone(key, perm);
}
```

So I'm quite happy with it. Just want to make sure I'm not missing anything.