### PR TITLE
Add compression options to 7zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -497,6 +497,6 @@ RUN printf "id ICON \"$PREFIX/src/w64devkit.ico\"" >w64devkit.rc \
  && cat /mingw-w64-v$MINGW_VERSION/mingw-w64-libraries/winpthreads/COPYING \
         >>$PREFIX/COPYING.MinGW-w64-runtime.txt \
  && echo $VERSION >$PREFIX/VERSION.txt \
- && 7z a -mx=9 $PREFIX.7z $PREFIX
+ && 7z a -t7z -mx=9 -mfb=273 -ms -md=31 -myx=9 -mtm=- -mmt -mmtf -md=1536m -mmf=bt3 -mmc=10000 -mpb=0 -mlc=0 $PREFIX.7z $PREFIX
 ENV PREFIX=${PREFIX}
 CMD cat /7z/7z.sfx $PREFIX.7z


### PR DESCRIPTION
Using some compression options allow shaving a few extra MB's off the archive.

It also removes the timestamps from the archive, so it might make it easier to make bit-for-bit reproducible builds.