### PR TITLE
gcc: Patch misaligned AVX spills (GCC bug 54412)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,6 @@ ported to Mingw-w64][san] ([also][san2]), but Undefined Behavior Sanitizer
 `-fsanitize-trap`, GDB will [break precisely][break] on undefined
 behavior, and it does not require linking with libsanitizer.
 
-[GCC does not fully support AVX on Windows][avx] and may use aligned moves
-on unaligned addresses. When targeting AVX, consider disabling all aligned
-moves in the assembler: `-Wa,-muse-unaligned-vector-move`.
-
 ## Licenses
 
 When distributing binaries built using w64devkit, your .exe will include
@@ -201,7 +197,6 @@ w64devkit includes the concatenated set of all licenses in the file
 binaries.
 
 
-[avx]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412
 [bb]: https://frippery.org/busybox/
 [break]: https://nullprogram.com/blog/2022/06/26/
 [bs]: https://www.rdegges.com/2016/i-dont-give-a-shit-about-licensing/

--- a/src/gcc-avx-misaligned.patch
+++ b/src/gcc-avx-misaligned.patch
@@ -1,0 +1,16 @@
+Treat AVX register spills as always unaligned, eliminating the
+requirement for -Wa,-muse-unaligned-vector-move when targeting
+AVX-capable hardware.
+
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412
+
+--- a/gcc/config/i386/predicates.md
++++ b/gcc/config/i386/predicates.md
+@@ -1695,5 +1695,6 @@
+ (define_predicate "misaligned_operand"
+   (and (match_code "mem")
+-       (match_test "MEM_ALIGN (op) < GET_MODE_BITSIZE (mode)")))
++       (ior (match_test "MEM_SIZE (op) > 16")
++            (match_test "MEM_ALIGN (op) < GET_MODE_BITSIZE (mode)"))))
+ 
+ ;; Return true if OP is a parallel for an mov{d,q,dqa,ps,pd} vec_select,


### PR DESCRIPTION
I believe this patch fixes [GCC bug 54412](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412), but it's a stab in the dark. I'd like more eyeballs on it, and help testing, especially because it mysteriously works better than I anticipated. That is, GCC still emits aligned moves when it's valid to do so, and it seems this only affects the cases that were broken (i.e. spills). I had expected some valid aligned moves would become unaligned, at probably some negligible (and acceptable) performance cost.

In the worst case I expect that this patch is incomplete, and there are still some misalignment crashes. I do not expect this breaks any code generation. The patch is unsuitable to go upstream as-is because it would affect all i386 targets, but perhaps it could be adapted into a general, upstreamable patch.

The GCC bug report contains a couple of sample programs that no longer crash after my patch. I've also tested llama.cpp (via `contrib/llama.mak`) with `-O2 -march=x86-64-v3`, which GCC would miscompile without `-Wa,-muse-unaligned-vector-move`. With this fix, it works fine without the special assembler flag.

If you'd like to help, for any programs you know that break with `-mavx` / `-march=x86-64-v3` / `-march=native` / etc., try building with this fix and see if it no longer crashes. I want to know if this patch (1) newly breaks anything, and (2) misses existing crashes related to AVX alignment. In case of (2), if I can't identify another keyhole patch I'll probably just restore the note in the README and be happy that at least this situation is less bad.