### PR TITLE
Use ftpmirror.gnu.org for downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,15 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
 
 RUN curl --insecure --location --remote-name-all --remote-header-name \
     https://downloads.sourceforge.net/project/sevenzip/7-Zip/23.01/7z$Z7_VERSION-src.tar.xz \
-    https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_VERSION.tar.xz \
-    https://ftp.gnu.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz \
-    https://ftp.gnu.org/gnu/gdb/gdb-$GDB_VERSION.tar.xz \
+    https://ftpmirror.gnu.org/gnu/binutils/binutils-$BINUTILS_VERSION.tar.xz \
+    https://ftpmirror.gnu.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.xz \
+    https://ftpmirror.gnu.org/gnu/gdb/gdb-$GDB_VERSION.tar.xz \
     https://downloads.sourceforge.net/project/expat/expat/$EXPAT_VERSION/expat-$EXPAT_VERSION.tar.xz \
-    https://ftp.gnu.org/gnu/gmp/gmp-$GMP_VERSION.tar.xz \
-    https://ftp.gnu.org/gnu/mpc/mpc-$MPC_VERSION.tar.gz \
-    https://ftp.gnu.org/gnu/mpfr/mpfr-$MPFR_VERSION.tar.xz \
-    https://ftp.gnu.org/gnu/make/make-$MAKE_VERSION.tar.gz \
-    https://ftp.gnu.org/gnu/libiconv/libiconv-$LIBICONV_VERSION.tar.gz \
+    https://ftpmirror.gnu.org/gnu/gmp/gmp-$GMP_VERSION.tar.xz \
+    https://ftpmirror.gnu.org/gnu/mpc/mpc-$MPC_VERSION.tar.gz \
+    https://ftpmirror.gnu.org/gnu/mpfr/mpfr-$MPFR_VERSION.tar.xz \
+    https://ftpmirror.gnu.org/gnu/make/make-$MAKE_VERSION.tar.gz \
+    https://ftpmirror.gnu.org/gnu/libiconv/libiconv-$LIBICONV_VERSION.tar.gz \
     https://frippery.org/files/busybox/busybox-w32-$BUSYBOX_VERSION.tgz \
     https://ftp.nluug.nl/pub/vim/unix/vim-$VIM_VERSION.tar.bz2 \
     https://github.com/universal-ctags/ctags/archive/refs/tags/v$CTAGS_VERSION.tar.gz \


### PR DESCRIPTION
llvm-mingw switched to using it in this commit:

https://github.com/mstorsjo/llvm-mingw/commit/a96bbc0c7fc69e0a7d86678fb3d8c0234d7eb7d2

And I figured we should do the same. Especially since we download more than just GNU make.

GNU themselves write:
We recommend using this generic ftpmirror.gnu.org address wherever possible in links, documentation, etc., to reduce load on the main GNU server. https://www.gnu.org/server/mirror.en.html