### PR TITLE
Add github actions workflow (with caching)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: Build and test
+
+concurrency:
+  group: w64devkit-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+  pull_request:
+    branches: [ "master" ]
+
+# Must set Settings -> Actions -> General -> Workflow permissions to
+# "Read and write permissions"
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["x64", "x86"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Apply x86 patch
+        if: matrix.arch == 'x86'
+        run: patch -p1 -i src/variant-x86.patch
+
+      - name: Generate archive name and version string
+        id: filename
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          GIT_VERSION="$(git describe --tags --always)"
+          echo "version=${GIT_VERSION:1}" >> $GITHUB_OUTPUT
+          echo "archive=w64devkit-$ARCH-${GIT_VERSION:1}" >> $GITHUB_OUTPUT
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          tags: w64devkit:${{ matrix.arch }}
+          load: true
+          cache-from: type=gha,scope=w64devkit-${{ matrix.arch }}
+          cache-to: type=gha,scope=w64devkit-${{ matrix.arch }},mode=max
+          
+      - name: Extract artifact
+        run: |
+          docker run --rm w64devkit:${{ matrix.arch }} > w64devkit.exe
+          
+      - name: Rename artifact
+        run: |
+          mv w64devkit.exe ${{ steps.filename.outputs.archive }}.exe
+          ls -lh ${{ steps.filename.outputs.archive }}.exe
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.filename.outputs.archive }}.exe
+          path: ${{ steps.filename.outputs.archive }}.exe
+          archive: false
+
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.filename.outputs.version }}
+          files: w64devkit-*.exe
+          draft: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -777,5 +777,5 @@ RUN printf "id ICON \"$PREFIX/src/w64devkit.ico\"" >w64devkit.rc \
  && cat /dl/mingw/mingw-w64-libraries/winpthreads/COPYING \
         >>$PREFIX/COPYING.MinGW-w64-runtime.txt \
  && echo $VERSION >$PREFIX/VERSION.txt \
- && 7z a -mx=9 -mtm=- $PREFIX.7z $PREFIX
-CMD cat /7z/7z.sfx $PREFIX.7z
+ && 7z a -mx=9 -mtm=- w64devkit.7z $PREFIX
+CMD ["cat", "/7z/7z.sfx", "w64devkit.7z"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ This takes about 15 minutes on modern systems. You will need an internet
 connection during the first few minutes of the build. **Note:** Do not use
 PowerShell because it lacks file redirection.
 
+# TEST
+Note that if you want a custom build, you can fork the repo, enable github actions
+push your commits and download the built artifacts.
+
 ## Usage
 
 The self-extracting 7z archive contains tools in a typical unix-like


### PR DESCRIPTION
This is a continuation of #72, the changes I added were to make caching work, so the CI doesn't have to download tarballs on every run.

~~I am not sure if the changes to the Dockerfile are necessary. I initially made them because exporting the image to layers or something like that was hanging, and it fixed that. Docker is not something I have a lot of knowledge about. My changes were LLM authored, but I did test them as thoroughly as I could.~~

They are not. Removed.