### PR TITLE
llama.mak: sync to b7376

### DIFF
--- a/contrib/llama.mak
+++ b/contrib/llama.mak
@@ -17,7 +17,7 @@
 #   $ make -j$(nproc) -f path/to/w64devkit/contrib/llama.mak
 #
 # Incremental builds are unsupported, so clean rebuild after pulling. It
-# was last tested at b7275, and an update will inevitably break it.
+# was last tested at b7376, and an update will inevitably break it.
 
 CROSS    =
 CPPFLAGS = -w -O2 -march=x86-64-v3
@@ -65,6 +65,7 @@ exe = \
   $(addsuffix .o,$(wildcard \
       common/*.cpp \
       tools/server/*.cpp \
+      tools/mtmd/models/*.cpp \
       vendor/cpp-httplib/*.cpp \
    ))
 


### PR DESCRIPTION
Updated last tested version from b7275 to b7376.