### PR TITLE
llama.mak: remove hardcoded GGML versioning

### DIFF
--- a/contrib/llama.mak
+++ b/contrib/llama.mak
@@ -17,7 +17,7 @@
 #   $ make -j$(nproc) -f path/to/w64devkit/contrib/llama.mak
 #
 # Incremental builds are unsupported, so clean rebuild after pulling. It
-# was last tested at b7376, and an update will inevitably break it.
+# was last tested at b7607, and an update will inevitably break it.
 
 CROSS    =
 CPPFLAGS = -w -O2 -march=x86-64-v3


### PR DESCRIPTION
Now that GGML's version has been bumped from 0.9.4 to 0.9.5, the hardcoded version in llama.mak is no longer correct. Instead, parse the version number out of the CMakeLists.txt and retrieve the commit hash using git if available.