### PR TITLE
llama.mak: support building Vulkan backend

### DIFF
--- a/contrib/llama.mak
+++ b/contrib/llama.mak
@@ -1,4 +1,4 @@
-# llama.cpp server and DLL build (CPU inference only)
+# llama.cpp server and DLL build (CPU or Vulkan inference)
 #
 # llama.cpp is an amazing project, but its build system is poor and
 # growing worse. It's never properly built llama.dll under any compiler,
@@ -16,12 +16,17 @@
 #
 #   $ make -j$(nproc) -f path/to/w64devkit/contrib/llama.mak
 #
+# To build with Vulkan GPU support, set VULKAN_SDK:
+#
+#   $ make ... VULKAN_SDK=C:/VulkanSDK/1.4.328.1
+#
 # Incremental builds are unsupported, so clean rebuild after pulling. It
 # was last tested at b8124, and an update will inevitably break it.
 
 CROSS    =
 CPPFLAGS = -w -O2 -march=x86-64-v3
 LDFLAGS  = -s
+HOST_CXX = c++
 
 .SUFFIXES: .c .cpp .o
 
@@ -49,10 +54,7 @@ inc = \
   -Itools/mtmd \
   -Ivendor \
   -Ivendor/cpp-httplib
-%.c.o: %.c
-	$(CROSS)gcc -c -o $@ $(inc) $(def) $(CPPFLAGS) $<
-%.cpp.o: %.cpp
-	$(CROSS)g++ -c -o $@ $(inc) $(def) $(CPPFLAGS) $<
+lib =
 
 dll = \
   $(addsuffix .o,$(wildcard \
@@ -65,7 +67,6 @@ dll = \
       src/*.cpp \
       src/models/*.cpp \
    ))
-
 exe = \
   tools/mtmd/clip.cpp.o \
   tools/mtmd/mtmd-audio.cpp.o \
@@ -81,13 +82,38 @@ exe = \
       vendor/cpp-httplib/*.cpp \
    ))
 
+ifdef VULKAN_SDK
+  GLSLC = $(VULKAN_SDK)/Bin/glslc.exe
+  vk_shaders_gen = vulkan-shaders-gen.exe
+  vk_build_dir = vk-shaders
+  vk_shader_header = $(vk_build_dir)/ggml-vulkan-shaders.hpp
+  vk_shaders = $(wildcard \
+    ggml/src/ggml-vulkan/vulkan-shaders/*.comp \
+  )
+  vk_shader_gen_obj = $(addsuffix .gen.o,$(wildcard \
+    ggml/src/ggml-vulkan/vulkan-shaders/*.cpp \
+  ))
+  vk_shader_objs = \
+    $(patsubst %.comp,$(vk_build_dir)/%.comp.cpp.o,$(notdir $(vk_shaders)))
+
+  def += -DGGML_USE_VULKAN
+  inc += -I$(VULKAN_SDK)/Include -I$(vk_build_dir)
+  lib += -L$(VULKAN_SDK)/Lib -lvulkan-1
+  dll += ggml/src/ggml-vulkan/ggml-vulkan.cpp.o $(vk_shader_objs)
+endif
+
+%.c.o: %.c
+	$(CROSS)gcc -c -o $@ $(inc) $(def) $(CPPFLAGS) $<
+%.cpp.o: %.cpp
+	$(CROSS)g++ -c -o $@ $(inc) $(def) $(CPPFLAGS) $<
+
 all: llama.dll llama.dll.a llama-server.exe
 
 llama-server.exe: $(exe) $(dll)
-	$(CROSS)g++ $(LDFLAGS) -o $@ $(exe) $(dll) -lws2_32
+	$(CROSS)g++ $(LDFLAGS) -o $@ $(exe) $(dll) -lws2_32 $(lib)
 
 llama.dll: $(dll) llama.def
-	$(CROSS)g++ -shared $(LDFLAGS) -o $@ $(dll) llama.def
+	$(CROSS)g++ -shared $(LDFLAGS) -o $@ $(dll) llama.def $(lib)
 
 llama.dll.a: llama.def
 	$(CROSS)dlltool -l $@ -d $^
@@ -95,7 +121,8 @@ llama.dll.a: llama.def
 clean:
 	rm -f $(dll) $(exe) llama.def llama.dll llama.dll.a llama-server.exe \
 	   tools/server/index.html.gz.hpp tools/server/loading.html.hpp \
-	   w64dk-build-info.cpp w64dk-license.c
+	   w64dk-build-info.cpp w64dk-license.c $(vk_shaders_gen)
+	rm -rf $(vk_build_dir)
 
 .ONESHELL:  # needed for heredocs
 
@@ -136,3 +163,42 @@ tools/server/server-http.cpp.o: \
 llama.def: $(dll)
 	printf 'LIBRARY llama\nEXPORTS\n' >$@
 	$(CROSS)nm -j $(dll) | grep '^llama_[a-z0-9_]\+$$' | sort >>$@
+
+# Vulkan shader generation rules
+ifdef VULKAN_SDK
+
+# vulkan-shaders-gen spawns multiple glslc processes per shader, for each
+# variant, so parallelizing it spawns hundreds of glslc processes and fails
+.NOTPARALLEL: $(vk_shader_objs)
+
+%.cpp.gen.o: %.cpp
+	$(HOST_CXX) -c -o $@ -std=c++17 -O2 \
+	  -Iggml/src/ggml-vulkan/vulkan-shaders $<
+$(vk_shaders_gen): $(vk_shader_gen_obj)
+	mkdir -p $(vk_build_dir)
+	$(HOST_CXX) -o $@ $(vk_shader_gen_obj)
+
+$(vk_shader_header): $(vk_shaders_gen) $(vk_shaders)
+	mkdir -p $(vk_build_dir)/vulkan-shaders.spv
+	./$(vk_shaders_gen) \
+	  --output-dir $(vk_build_dir)/vulkan-shaders.spv \
+	  --target-hpp $(vk_shader_header)
+
+$(vk_build_dir)/%.comp.cpp: \
+  ggml/src/ggml-vulkan/vulkan-shaders/%.comp \
+  $(vk_shaders_gen) \
+  $(vk_shader_header)
+	./$(vk_shaders_gen) \
+	  --glslc $(GLSLC) \
+	  --source $< \
+	  --output-dir $(vk_build_dir)/vulkan-shaders.spv \
+	  --target-hpp $(vk_shader_header) \
+	  --target-cpp $@
+
+# Pattern rule: compile each shader .cpp to .o
+$(vk_build_dir)/%.comp.cpp.o: $(vk_build_dir)/%.comp.cpp
+	$(CROSS)g++ -c -o $@ $(inc) $(def) $(CPPFLAGS) $<
+
+ggml/src/ggml-vulkan/ggml-vulkan.cpp.o: $(vk_shader_header)
+
+endif  # VULKAN_SDK


### PR DESCRIPTION
Requires the Vulkan SDK installed to build.
It can be downloaded from: https://vulkan.lunarg.com/