### PR TITLE
Swap PDCurses for ncurses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,16 +81,16 @@ RUN curl --insecure --location --remote-name-all --remote-header-name \
  && mkdir libiconv \
  && tar xzf libiconv-$LIBICONV_VERSION.tar.gz -C libiconv --strip-components=1
 
-FROM base AS dl-pdcurses
-ARG PDCURSES_VERSION=3.9 \
-    PDCURSES_SHA256=590dbe0f5835f66992df096d3602d0271103f90cf8557a5d124f693c2b40d7ec
+FROM base AS dl-ncurses
+ARG NCURSES_VERSION=6.6 \
+    NCURSES_SHA256=355b4cbbed880b0381a04c46617b7656e362585d52e9cf84a67e2009b749ff11
 WORKDIR /dl
 RUN curl --insecure --location --remote-name-all --remote-header-name \
-    https://downloads.sourceforge.net/project/pdcurses/pdcurses/$PDCURSES_VERSION/PDCurses-$PDCURSES_VERSION.tar.gz \
- && printf '%s  %s\n' $PDCURSES_SHA256 PDCurses-$PDCURSES_VERSION.tar.gz \
+    https://invisible-island.net/archives/ncurses/ncurses-$NCURSES_VERSION.tar.gz \
+ && printf '%s  %s\n' $NCURSES_SHA256 ncurses-$NCURSES_VERSION.tar.gz \
     | sha256sum -c \
- && mkdir pdcurses \
- && tar xzf PDCurses-$PDCURSES_VERSION.tar.gz -C pdcurses --strip-components=1
+ && mkdir ncurses \
+ && tar xzf ncurses-$NCURSES_VERSION.tar.gz -C ncurses --strip-components=1
 
 FROM base AS dl-make
 ARG MAKE_VERSION=4.4.1 \
@@ -479,21 +479,38 @@ RUN ./configure \
  && $ARCH-gcc -nostartfiles -Oz -s -o /out/bin/uuidgen.exe \
         $PREFIX/src/uuidgen.c -lmemory
 
-# Build PDCurses once and reuse it for both gdb and ccmake.
-FROM cross AS build-pdcurses
-COPY --from=dl-pdcurses /dl/pdcurses /dl/pdcurses
+# Build ncurses once and reuse it for both gdb and ccmake.
+FROM cross AS build-ncurses
+COPY --from=dl-ncurses /dl/ncurses /dl/ncurses
 
-WORKDIR /dl/pdcurses
-RUN make -j$(nproc) -C wincon \
-       CC=$ARCH-gcc AR=$ARCH-ar CFLAGS="-I.. -O2 -DPDC_WIDE" pdcurses.a \
- && mkdir -p /deps/lib /deps/include \
- && cp wincon/pdcurses.a /deps/lib/libcurses.a \
- && cp curses.h /deps/include/curses.h
+WORKDIR /ncurses
+RUN /dl/ncurses/configure \
+        --host=$ARCH \
+        --without-ada \
+        --without-cxx-binding \
+        --enable-widec \
+        --enable-term-driver \
+        --enable-sp-funcs \
+        --with-fallbacks=ms-terminal \
+        --without-progs \
+        --without-tests \
+        --without-manpages \
+        --without-debug \
+        --disable-database \
+        --disable-shared \
+        --prefix=/deps \
+        CFLAGS="-O2" \
+        LDFLAGS="-s" \
+ && make -j$(nproc) \
+ && make install
+RUN printf 'CREATE /deps/lib/libcurses.a\nADDLIB /deps/lib/libncursesw.a\nADDLIB /deps/lib/libpanelw.a\nADDLIB /deps/lib/libformw.a\nADDLIB /deps/lib/libmenuw.a\nSAVE\nEND\n' | $ARCH-ar -M \
+ && rm /deps/lib/libncursesw.a /deps/lib/libpanelw.a /deps/lib/libformw.a /deps/lib/libmenuw.a \
+ && sed -i '1s/^/#define NCURSES_STATIC\n/' /deps/include/ncursesw/ncurses_dll.h
 
 FROM cross AS build-gdb
 COPY --from=dl-gdb /dl/ /dl/
-COPY --from=build-pdcurses /deps/lib/libcurses.a /deps/lib/
-COPY --from=build-pdcurses /deps/include/curses.h /deps/include/
+COPY --from=build-ncurses /deps/lib/libcurses.a /deps/lib/
+COPY --from=build-ncurses /deps/include/ /deps/include/
 
 WORKDIR /expat
 RUN /dl/expat/configure \
@@ -526,10 +543,10 @@ RUN cat $PREFIX/src/gdb-*.patch | patch -d/dl/gdb -p1 \
  && /dl/gdb/configure \
         --host=$ARCH \
         --enable-tui \
-        CFLAGS="-std=gnu17 -O2 -D__MINGW_USE_VC2005_COMPAT -DPDC_WIDE -I/deps/include" \
-        CXXFLAGS="-O2 -D__MINGW_USE_VC2005_COMPAT -DPDC_WIDE -I/deps/include" \
-        LDFLAGS="-s -L/deps/lib" \
- && make MAKEINFO=true -j$(nproc) \
+        CFLAGS="-std=gnu17 -O2 -D__MINGW_USE_VC2005_COMPAT -DNCURSES_STATIC -I/deps/include -I/deps/include/ncursesw" \
+        CXXFLAGS="-O2 -D__MINGW_USE_VC2005_COMPAT -DNCURSES_STATIC -I/deps/include -I/deps/include/ncursesw" \
+        LDFLAGS="-s -L/deps/lib"
+RUN make MAKEINFO=true -j$(nproc) \
  && mkdir -p /out/bin \
  && cp gdb/.libs/gdb.exe gdbserver/gdbserver.exe /out/bin/
 
@@ -704,8 +721,8 @@ RUN cmake -DCMAKE_BUILD_TYPE=Release \
 
 FROM cross AS build-cmake
 COPY --from=dl-cmake /dl/ /dl/
-COPY --from=build-pdcurses /deps/lib/libcurses.a /deps/lib/
-COPY --from=build-pdcurses /deps/include/curses.h /deps/include/
+COPY --from=build-ncurses /deps/lib/libcurses.a /deps/lib/
+COPY --from=build-ncurses /deps/include/ /deps/include/
 
 WORKDIR /cmake
 COPY src/cmake-*.patch $PREFIX/src/
@@ -719,7 +736,7 @@ RUN cat $PREFIX/src/cmake-*.patch | patch -d/dl/cmake -p1 \
         -DCMAKE_INSTALL_PREFIX=$PREFIX \
         -DBUILD_CursesDialog=ON \
         -DCURSES_LIBRARY=/deps/lib/libcurses.a \
-        -DCURSES_INCLUDE_PATH=/deps/include \
+        -DCURSES_INCLUDE_PATH=/deps/include/ncursesw \
         -DBUILD_QtDialog=OFF \
         -DBUILD_TESTING=OFF \
         -DCMAKE_USE_OPENSSL=OFF \

--- a/src/variant-x86.patch
+++ b/src/variant-x86.patch
@@ -1,51 +1,82 @@
---- a/Dockerfile
-+++ b/Dockerfile
-@@ -167,3 +167,3 @@ RUN curl --insecure --location --remote-name-all --remote-header-name \
+--- a/Dockerfile	2026-03-18 13:02:04.857926873 +0000
++++ b/Dockerfile	2026-03-18 13:02:04.859390567 +0000
+@@ -190,7 +190,7 @@
+ # Build cross-compiler
+ 
  FROM dl-cross AS cross
 -ARG ARCH=x86_64-w64-mingw32
 +ARG ARCH=i686-w64-mingw32
  ENV ARCH=$ARCH
-@@ -198,2 +198,3 @@ RUN echo '#include <crtdefs.h>' \
+ 
+ WORKDIR /dl/binutils
+@@ -221,6 +221,7 @@
+         --prefix=/bootstrap \
+         --host=$ARCH \
          --with-default-msvcrt=msvcrt-os \
 +        --with-default-win32-winnt=0x0501 \
   && make -j$(nproc) \
-@@ -210,2 +211,3 @@ RUN cat $PREFIX/src/gcc-*.patch | patch -d/dl/gcc -p1 \
+  && make install
+ 
+@@ -233,6 +234,7 @@
+  && /dl/gcc/configure \
+         --prefix=/bootstrap \
          --with-sysroot=/bootstrap \
 +        --with-arch=pentium4 \
          --target=$ARCH \
-@@ -250,4 +252,4 @@ RUN /dl/mingw/mingw-w64-crt/configure \
-         --disable-dependency-tracking \
--        --disable-lib32 \
--        --enable-lib64 \
-+        --enable-lib32 \
-+        --disable-lib64 \
-         CFLAGS="-O2" \
-@@ -336,2 +338,3 @@ RUN /dl/mingw/mingw-w64-headers/configure \
+         --enable-static \
+         --disable-shared \
+@@ -273,8 +275,8 @@
+         --host=$ARCH \
          --with-default-msvcrt=msvcrt-os \
-+        --with-default-win32-winnt=0x0501 \
-  && make -j$(nproc) \
-@@ -346,4 +349,4 @@ RUN /dl/mingw/mingw-w64-crt/configure \
          --disable-dependency-tracking \
 -        --disable-lib32 \
 -        --enable-lib64 \
 +        --enable-lib32 \
 +        --disable-lib64 \
          CFLAGS="-O2" \
-@@ -374,2 +377,3 @@ RUN echo 'BEGIN {print "pecoff"}' \
+         LDFLAGS="-s" \
+  && make -j$(nproc) \
+@@ -369,8 +371,8 @@
+         --host=$ARCH \
+         --with-default-msvcrt=msvcrt-os \
+         --disable-dependency-tracking \
+-        --disable-lib32 \
+-        --enable-lib64 \
++        --enable-lib32 \
++        --disable-lib64 \
+         CFLAGS="-O2" \
+         LDFLAGS="-s" \
+  && make -j$(nproc) \
+@@ -397,6 +399,7 @@
+         --prefix=$PREFIX \
+         --with-sysroot=$PREFIX \
          --with-native-system-header-dir=/include \
 +        --with-arch=pentium4 \
          --target=$ARCH \
-@@ -392,2 +396,3 @@ RUN echo 'BEGIN {print "pecoff"}' \
+         --host=$ARCH \
+         --enable-static \
+@@ -415,6 +418,7 @@
+         --disable-multilib \
+         --disable-nls \
          --disable-win32-registry \
 +        --disable-win32-utf8-manifest \
          --enable-mingw-wildcard \
-@@ -528,3 +533,3 @@ COPY src/busybox-* $PREFIX/src/
+         CFLAGS_FOR_TARGET="-O2" \
+         CXXFLAGS_FOR_TARGET="-O2" \
+@@ -576,7 +580,7 @@
+ WORKDIR /dl/busybox
+ COPY src/busybox-* $PREFIX/src/
  RUN cat $PREFIX/src/busybox-*.patch | patch -p1 \
 - && make mingw64u_defconfig \
 + && make mingw64_defconfig \
   && sed -ri 's/^(CONFIG_AR)=y/\1=n/' .config \
-@@ -721,3 +729,4 @@ RUN cat $PREFIX/src/cmake-*.patch | patch -d/dl/cmake -p1 \
+  && sed -ri 's/^(CONFIG_ASCII)=y/\1=n/' .config \
+  && sed -ri 's/^(CONFIG_DPKG\w*)=y/\1=n/' .config \
+@@ -735,6 +739,7 @@
+         -DCMAKE_CXX_COMPILER=$ARCH-g++ \
+         -DCMAKE_RC_COMPILER=$ARCH-windres \
          -DCMAKE_EXE_LINKER_FLAGS="-s" \
 +        -DCMAKE_CXX_FLAGS="-O2 -D_WIN32_WINNT=0x0601" \
          -DCMAKE_INSTALL_PREFIX=$PREFIX \
          -DBUILD_CursesDialog=ON \
+         -DCURSES_LIBRARY=/deps/lib/libcurses.a \


### PR DESCRIPTION
This was figured out by Claude Code working autonomously over ~12 hours. It works, but overall it's worse than PDCurses. I cannot tell the difference in `ccmake`, but in `gdb`:

* Background colors, like line numbers being highlighted (slightly better)
* No support for `C-a` or `C-e` (big downgrade)
* Unrecognized modified keys are treated as unmodified, .e.g. `M-f` is `f`. PDCurses ignores `M-f`. (slightly worse)
* Neither can actually handle wide characters. (no change)

I wanted to capture this somewhere, and perhaps some of this could be addressed in the future.