### PR TITLE
make: normalize backslashes in env-imported variable values

### DIFF
--- a/src/make-normalize-env-paths.patch
+++ b/src/make-normalize-env-paths.patch
@@ -1,0 +1,44 @@
+Normalize backslashes in environment-imported variable values
+
+On Windows, environment variables like VULKAN_SDK, LIB, INCLUDE, etc.
+commonly contain backslash-separated paths (e.g. C:\SDK\Include). When
+GNU Make expands these variables into recipe lines and passes them to a
+unixy shell (BusyBox ash, MSYS2 sh, etc.), the shell interprets each
+backslash as an escape character, silently mangling the paths.
+
+Fix this by normalizing backslashes to forward slashes in all variable
+values imported from the Windows environment, immediately after they are
+stored. Forward slashes are accepted by all Windows APIs and all Windows
+compilers, so this transformation is safe regardless of whether the
+shell in use is unixy or cmd.exe.
+
+This mirrors the behavior of BusyBox-w32 ash, which performs the same
+normalization in setwinxp() when it imports variables from the Windows
+environment into the shell's variable table.
+
+--- a/src/main.c
++++ b/src/main.c
+@@ -1535,6 +1535,23 @@
+ 
+         v = define_variable (envp[i], len, ep, o_env, 1);
+ 
++#ifdef WINDOWS32
++        /* Normalize backslashes to forward slashes in all environment-imported
++           variable values.  On Windows, backslashes in environment variables
++           are virtually always path separators, and all Windows APIs accept
++           forward slashes in their place.  Normalizing here ensures that
++           $(VAR) expansions in recipes already contain forward slashes before
++           the shell sees them, mirroring what BusyBox-w32 ash does in
++           setwinxp() when it imports variables from the Windows environment.  */
++        if (v && v->value)
++          {
++            char *vp;
++            for (vp = v->value; *vp != '\0'; ++vp)
++              if (*vp == '\\')
++                *vp = '/';
++          }
++#endif /* WINDOWS32 */
++
+         /* POSIX says the value of SHELL set in the makefile won't change the
+            value of SHELL given to subprocesses.  */
+         if (streq (v->name, "SHELL"))


### PR DESCRIPTION
On Windows, the VULKAN_SDK environment variable, as set by the Vulkan SDK qt ifw installer contain backslash-separated paths. When GNU Make expands these into recipe lines passed to a unixy shell, the backslashes make it over to the shell command, where they are treated as escape characters, mangling the paths.

As a result, using `make -f llama.mak` would fail to build, if invoked from powershell, on a system with the vulkan SDK installed.

Normalize backslashes to forward slashes in all variable values imported from the Windows environment at startup, when a "unixy" shell is being used.  This is the same thing that BusyBox-w32 ash does in setwinxp() on shell startup.