### PR TITLE
binutils-gdb: Fix wrong code page

### DIFF
--- a/src/binutils-fix-path-corruption.patch
+++ b/src/binutils-fix-path-corruption.patch
@@ -1,0 +1,17 @@
+diff --git a/bfd/bfdio.c b/bfd/bfdio.c
+index ea0d1389cd1..187763eb444 100644
+--- a/bfd/bfdio.c
++++ b/bfd/bfdio.c
+@@ -189,11 +189,7 @@ _bfd_real_fopen (const char *filename, const char *modes)
+     }
+ 
+ #ifdef __MINGW32__
+-#if !HAVE_DECL____LC_CODEPAGE_FUNC
+-  /* This prototype was added to locale.h in version 9.0 of MinGW-w64.  */
+-  _CRTIMP unsigned int __cdecl ___lc_codepage_func (void);
+-#endif
+-  const unsigned int cp = ___lc_codepage_func ();
++  const unsigned int cp = CP_ACP;
+ #else
+   const unsigned int cp = CP_UTF8;
+ #endif

--- a/src/gdb-fix-iconv-cp65001.patch
+++ b/src/gdb-fix-iconv-cp65001.patch
@@ -1,0 +1,18 @@
+diff --git a/gdb/charset.c b/gdb/charset.c
+index 5835fd40872..21d7ad03728 100644
+--- a/gdb/charset.c
++++ b/gdb/charset.c
+@@ -1029,8 +1029,11 @@ _initialize_charset (void)
+     /* "CP" + x<=5 digits + paranoia.  */
+     static char w32_host_default_charset[16];
+ 
+-    snprintf (w32_host_default_charset, sizeof w32_host_default_charset,
+-	      "CP%d", GetACP());
++    if (GetACP () == CP_UTF8)
++      strncpy (w32_host_default_charset, "UTF-8", sizeof w32_host_default_charset);
++    else
++      snprintf (w32_host_default_charset, sizeof w32_host_default_charset,
++                "CP%d", GetACP());
+     auto_host_charset_name = w32_host_default_charset;
+     auto_target_charset_name = auto_host_charset_name;
+   }

--- a/src/gdb-fix-path-corruption.patch
+++ b/src/gdb-fix-path-corruption.patch
@@ -1,0 +1,17 @@
+diff --git a/bfd/bfdio.c b/bfd/bfdio.c
+index ea0d1389cd1..187763eb444 100644
+--- a/bfd/bfdio.c
++++ b/bfd/bfdio.c
+@@ -189,11 +189,7 @@ _bfd_real_fopen (const char *filename, const char *modes)
+     }
+ 
+ #ifdef __MINGW32__
+-#if !HAVE_DECL____LC_CODEPAGE_FUNC
+-  /* This prototype was added to locale.h in version 9.0 of MinGW-w64.  */
+-  _CRTIMP unsigned int __cdecl ___lc_codepage_func (void);
+-#endif
+-  const unsigned int cp = ___lc_codepage_func ();
++  const unsigned int cp = CP_ACP;
+ #else
+   const unsigned int cp = CP_UTF8;
+ #endif


### PR DESCRIPTION
Binutils-gdb fetch code page for path conversion from ___lc_codepage_func(). When building with msvcrt, ___lc_codepage_func does not return the code page that file APIs accept and return, or argv encoded in; it returns "the default code page for Windows display language".

When (1) checking "Beta: USE Unicode UTF-8 for worldwide language support", or (2) setting "Current system locale" to some value differ from current display language, the path is corrupted during conversion and binutils and gdb cannot use non-ASCII filenames (even they are encode-able in current code page).

Also, gdb passes "CP\<ACP>" to iconv, but "CP65001" is not a valid encoding name. Explicitly handling CP_UTF8 fixes it.